### PR TITLE
Fix /dev/null redirection in ae-fields DATE case

### DIFF
--- a/SCRIPTS/ae-fields.sh
+++ b/SCRIPTS/ae-fields.sh
@@ -141,7 +141,7 @@ while IFS= read -r line; do
         gh project item-edit --id "$item_id" --field-name "$fname" --single-select "$val" >/dev/null
         ;;
       DATE)
-        gh project item-edit --id "$item_id" --field-name "$fname" --date "$val" >/devnull
+        gh project item-edit --id "$item_id" --field-name "$fname" --date "$val" >/dev/null
         ;;
       *)
         gh project item-edit --id "$item_id" --field-name "$fname" --text "$val" >/dev/null


### PR DESCRIPTION
## Summary
- redirect DATE field updates to `/dev/null`

## Testing
- `shellcheck SCRIPTS/ae-fields.sh`

------
https://chatgpt.com/codex/tasks/task_b_68999bbf38008323b29263f815b22cca