### PR TITLE
Ensure TSV parsing preserves empty fields

### DIFF
--- a/SCRIPTS/aa-labels.sh
+++ b/SCRIPTS/aa-labels.sh
@@ -54,7 +54,10 @@ done
 # collect labels from file (fresh parse)
 declare -A NEED
 while IFS= read -r line; do
-  IFS="$DELIM" read -r -a vals <<< "$(printf '%s' "$line" | tr -d '\r')"
+  mapfile -t vals < <(
+    printf '%s' "$line" | tr -d '\r' |
+    awk -v FS="$DELIM" '{for(i=1;i<=NF;i++) print $i}'
+  )
   for idx in "${LABEL_IDXS[@]}"; do
     v="${vals[$idx]:-}"
     # trim

--- a/SCRIPTS/ab-issues.sh
+++ b/SCRIPTS/ab-issues.sh
@@ -62,7 +62,10 @@ MAP_OUT="OUTPUTS/issue_map.tsv"
 : > "$MAP_OUT"
 
 while IFS= read -r line; do
-  IFS="$DELIM" read -r -a vals <<< "$(printf '%s' "$line" | tr -d '\r')"
+  mapfile -t vals < <(
+    printf '%s' "$line" | tr -d '\r' |
+    awk -v FS="$DELIM" '{for(i=1;i<=NF;i++) print $i}'
+  )
 
   title="${vals[$TITLE_IDX]:-}"
   [[ -z "$title" ]] && { echo "skip: empty title"; continue; }

--- a/SCRIPTS/ac-subissues.sh
+++ b/SCRIPTS/ac-subissues.sh
@@ -69,7 +69,10 @@ TMPDIR="$(mktemp -d)"; trap 'rm -rf "$TMPDIR"' EXIT
 
 # Process rows
 while IFS= read -r line; do
-  IFS="$DELIM" read -r -a vals <<< "$(printf '%s' "$line" | tr -d '\r')"
+  mapfile -t vals < <(
+    printf '%s' "$line" | tr -d '\r' |
+    awk -v FS="$DELIM" '{for(i=1;i<=NF;i++) print $i}'
+  )
 
   ptitle="${vals[$TITLE_IDX]:-}"
   [[ -z "$ptitle" ]] && { echo "skip: empty parent title"; continue; }

--- a/SCRIPTS/ae-fields.sh
+++ b/SCRIPTS/ae-fields.sh
@@ -120,7 +120,10 @@ done < "$PARENT_MAP"
 
 # ---- Apply values to items ----
 while IFS= read -r line; do
-  IFS="$DELIM" read -r -a vals <<< "$(printf '%s' "$line" | tr -d '\r')"
+  mapfile -t vals < <(
+    printf '%s' "$line" | tr -d '\r' |
+    awk -v FS="$DELIM" '{for(i=1;i<=NF;i++) print $i}'
+  )
   title="${vals[$TITLE_IDX]:-}"
   [[ -z "$title" ]] && continue
 


### PR DESCRIPTION
## Summary
- Replace IFS-based array splitting with awk-backed mapfile pipeline to keep empty columns across label, issue, sub-issue, and project field scripts.

## Testing
- `bash -n SCRIPTS/aa-labels.sh SCRIPTS/ab-issues.sh SCRIPTS/ac-subissues.sh SCRIPTS/ae-fields.sh`
- `shellcheck SCRIPTS/aa-labels.sh SCRIPTS/ab-issues.sh SCRIPTS/ac-subissues.sh SCRIPTS/ae-fields.sh`

------
https://chatgpt.com/codex/tasks/task_b_68999ba3b69483239d6ca42202370c87