### PR TITLE
Use PAT for @me projects in manual-import workflow

### DIFF
--- a/.github/workflows/manual-import.yml
+++ b/.github/workflows/manual-import.yml
@@ -45,7 +45,7 @@ permissions:
 # Global env & defaults for convenience
 env:
   GH_REPO: ${{ github.repository }}
-  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}        # zero-edit auth; gh will auto-use this
+  GH_TOKEN: ${{ inputs.project_owner == '@me' && secrets.GH_PAT || secrets.GITHUB_TOKEN }}  # use PAT for @me projects
   PROJECT_OWNER: ${{ inputs.project_owner }}
   PROJECT_TITLE: ${{ inputs.project_title }}
 


### PR DESCRIPTION
## Summary
- Use GH_PAT when `project_owner` is `@me` and fall back to `GITHUB_TOKEN` otherwise

## Testing
- `npm test` *(fails: ENOENT package.json)*
- `pytest` *(no tests ran)*

------
https://chatgpt.com/codex/tasks/task_b_689ad6ee19688323bc2ba48591b8158c