### PR TITLE
feat(workflow): add link issues job

### DIFF
--- a/.github/workflows/manual-import.yml
+++ b/.github/workflows/manual-import.yml
@@ -36,6 +36,18 @@ on:
         description: Run project fields step
         type: boolean
         default: true
+      run_link_issues:
+        description: Run link issues step
+        type: boolean
+        default: false
+      link_parent:
+        description: Parent issue to link children under
+        type: string
+        required: false
+      link_children:
+        description: Child issues to link (space- or comma-delimited)
+        type: string
+        required: false
 
 permissions:
   contents: write
@@ -136,3 +148,24 @@ jobs:
           git add OUTPUTS/*
           git commit -m "Save workflow outputs" || echo "No changes"
           git push
+
+  link_issues:
+    if: ${{ inputs.run_link_issues }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Prepare scripts
+        run: |
+          set -euo pipefail
+          chmod +x SCRIPTS/*.sh
+          mkdir -p OUTPUTS
+
+      - name: Link issues
+        run: |
+          bash SCRIPTS/af-link-only.sh \
+            "${{ inputs.link_parent }}" ${{ inputs.link_children }}

--- a/.github/workflows/manual-import.yml
+++ b/.github/workflows/manual-import.yml
@@ -28,6 +28,10 @@ on:
         description: Run sub-issues step
         type: boolean
         default: true
+      run_link_issues:
+        description: Run link issues step
+        type: boolean
+        default: true        
       run_project:
         description: Run project step (create/reuse + add items)
         type: boolean
@@ -36,18 +40,15 @@ on:
         description: Run project fields step
         type: boolean
         default: true
-      run_link_issues:
-        description: Run link issues step
-        type: boolean
-        default: false
-      link_parent:
-        description: Parent issue to link children under
-        type: string
-        required: false
-      link_children:
-        description: Child issues to link (space- or comma-delimited)
-        type: string
-        required: false
+
+#      link_parent:
+#        description: Parent issue to link children under
+#        type: string
+#        required: false
+#      link_children:
+#        description: Child issues to link (space- or comma-delimited)
+#        type: string
+#        required: false
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary
- add `run_link_issues`, `link_parent`, and `link_children` inputs to workflow_dispatch
- add `link_issues` job to call `af-link-only.sh`

## Testing
- `yamllint .github/workflows/manual-import.yml` *(fails: line too long in existing code)*

------
https://chatgpt.com/codex/tasks/task_b_689bc7a5b5a0832384606ad8d3ea0940