### PR TITLE
chore: fallback to default GitHub token

### DIFF
--- a/.github/workflows/link-subissues.yml
+++ b/.github/workflows/link-subissues.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Run scanner (all issues; no inputs)
         env:
-          GH_TOKEN: ${{ secrets.GH_PAT }}   # your PAT
+          GH_TOKEN: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}   # custom PAT or default token
         shell: bash
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Summary
- allow `link-subissues` workflow to fall back to `GITHUB_TOKEN`

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689c267e1c388323b895634162d550de