### PR TITLE
Default scripts to repository context and simplify project linking

### DIFF
--- a/.github/workflows/manual-import-v3.yml
+++ b/.github/workflows/manual-import-v3.yml
@@ -77,7 +77,7 @@ jobs:
     env:
       GH_REPO: ${{ github.repository }}
       GH_TOKEN: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
-      PROJECT_OWNER: ${{ inputs.project_owner || github.repository_owner }}
+      PROJECT_OWNER: ${{ inputs.project_owner }}
       PROJECT_TITLE: ${{ inputs.project_title }}
       PARENT_MAP: OUTPUTS/issue_map.tsv
       SUBMAP: OUTPUTS/subissue_map.tsv

--- a/OUTPUTS/errors.md
+++ b/OUTPUTS/errors.md
@@ -4,3 +4,6 @@
 ---
 - [2025-08-16 00:27:50] source: Manual Import v3/import | script: SCRIPTS/ae-fields.sh | line: 125 | exit: 1 | cmd: gh project field-create "$PROJECT_NUMBER" --owner "$PROJECT_OWNER" --name "$name" --data-type "$type" --single-select-options "$options_string" > /dev/null
 
+---
+- [2025-08-16 02:18:06] source: Manual Import v3/import | script: SCRIPTS/ae-fields.sh | line: 119 | exit: 1 | cmd: gh project field-create "$PROJECT_NUMBER" --owner "$PROJECT_OWNER" --name "$name" --data-type "$type" --single-select-options "$options_string" > /dev/null
+

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ OUTPUTS/         # generated maps/outputs
 1) **Labels (idempotent)** — creates only missing labels.
 2) **Issues (create‑only)** — creates issues; attaches all `*label*` columns; body passed verbatim via `--body-file`. Produces `OUTPUTS/issue_map.tsv`.
 3) **Sub‑issues (create‑only)** — splits parent body on `;`, creates child issues, links them back. Produces `OUTPUTS/subissue_map.tsv`.
-4) **Project (idempotent)** — creates or reuses project; links the repository (if `GH_REPO` set); adds all issue URLs; saves number to `OUTPUTS/project_number.txt`.
+4) **Project (idempotent)** — creates or reuses project; links the repository; adds all issue URLs; saves number to `OUTPUTS/project_number.txt`.
 5) **Fields (idempotent)** — creates fields/options if missing; applies values from `PROJECT_FIELD_*[:TYPE]`.
 
 ## Notes
@@ -97,7 +97,7 @@ Order of operation (alphabetical naming keeps them in sequence):
 
 4. **ad-project.sh**
    - Creates or reuses a GitHub Project
-   - Links the project to `GH_REPO` when provided
+   - Links the project to the repository
    - Adds all issues and sub-issues to the project
    - Saves project number to `OUTPUTS/project_number.txt`
 
@@ -150,7 +150,6 @@ Go to **Actions → Manual Import → Run workflow**. Fill in:
 ---
 
 ### **What you don’t need to enter**
-- **GH_REPO** — auto-set by the workflow
 - **PROJECT_NUMBER** — auto-detected from the created/reused project
 - **Script paths** — workflow handles them
 - **Auth during run** — handled via GH_TOKEN or GH_PAT
@@ -231,7 +230,6 @@ chmod +x aa-labels.sh ab-issues.sh ac-subissues.sh ad-project.sh ae-fields.sh
 gh auth login
 
 # set environment variables for this shell (PROJECT_NUMBER is read from OUTPUTS/project_number.txt)
-export GH_REPO="<you>/<repo>"
 export DATA_FILE="data/PLANNERv9.1.tsv"
 export PROJECT_OWNER="@me"              # or your org name
 export PROJECT_TITLE="Imported Plan"    # project name you want
@@ -278,7 +276,6 @@ export PROJECT_TITLE="Imported Plan"    # project name you want
 
 ## Common pitfalls
 - Not authenticated: run `gh auth login`.
-- Wrong repo: ensure `export GH_REPO="<you>/<repo>"` is set before running.
 - Missing Bash 4+: install a newer bash and run the scripts with that interpreter.
 - CSV with quoted commas: these scripts are tuned for TSV. If you must use CSV with complex quoting, consider converting to TSV first.
 

--- a/SCRIPTS/ab-issues.sh
+++ b/SCRIPTS/ab-issues.sh
@@ -8,21 +8,19 @@ Usage: $(basename "$0") [DATA_FILE or GLOB]
 Creates issues from TSV/CSV. No idempotency (re-runs will create duplicates).
 
 Env:
-  GH_REPO   (required)  e.g. owner/repo
   DATA_FILE (optional)  used if no positional arg
 
 Outputs:
-  OUTPUTS/issue_map.tsv   (Title \\t URL \\t Number)
+  OUTPUTS/issue_map.tsv   (Title \t URL \t Number)
 
 Examples:
-  GH_REPO=owner/repo ./SCRIPTS/ab-issues.sh TSV_HERE/*.tsv
-  GH_REPO=owner/repo DATA_FILE=TSV_HERE/PLANNERv9.1.tsv ./SCRIPTS/ab-issues.sh
+  ./SCRIPTS/ab-issues.sh TSV_HERE/*.tsv
+  DATA_FILE=TSV_HERE/PLANNERv9.1.tsv ./SCRIPTS/ab-issues.sh
 EOF
 }
 
 [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]] && { usage; exit 0; }
 
-: "${GH_REPO:?Set GH_REPO=owner/repo}"
 DATA_SPEC="${1:-${DATA_FILE:-}}"
 [[ -n "$DATA_SPEC" ]] || { echo "ERROR: provide DATA_FILE or glob (arg or env)."; usage; exit 1; }
 
@@ -39,7 +37,6 @@ else
 fi
 shopt -u nullglob
 
-GH_REPO_FLAG=(--repo "$GH_REPO")
 DELIM=$'\t'; [[ "$DATA_FILE" == *.csv ]] && DELIM=','
 
 mkdir -p OUTPUTS
@@ -90,7 +87,7 @@ while IFS= read -r line; do
   fi
 
   echo "create: $title"
-  url="$(run_cmd gh "${GH_REPO_FLAG[@]}" issue create --title "$title" --body-file "$body_file" "${label_args[@]}")"
+  url="$(run_cmd gh issue create --title "$title" --body-file "$body_file" "${label_args[@]}")"
   if [[ -z "$url" ]]; then
     echo "warn: failed to create issue: $title (see OUTPUTS/errors.md)" >&2
     continue
@@ -103,3 +100,4 @@ while IFS= read -r line; do
 done < <(tail -n +2 "$DATA_FILE")
 
 echo "issues done (source: $DATA_FILE). map: $MAP_OUT"
+

--- a/SCRIPTS/ae-fields.sh
+++ b/SCRIPTS/ae-fields.sh
@@ -8,7 +8,7 @@ Usage: $(basename "$0") [DATA_FILE or GLOB]
 Ensures project fields/options exist (idempotent) and applies values to each item.
 
 Env:
-  PROJECT_OWNER (optional)   defaults to GH_REPO owner
+  PROJECT_OWNER (optional)   defaults to repo owner
   PROJECT_NUMBER (optional)  numeric project id; defaults to OUTPUTS/project_number.txt
   DATA_FILE (optional)       used if no positional arg
   PARENT_MAP (optional)      default OUTPUTS/issue_map.tsv
@@ -22,14 +22,8 @@ EOF
 
 [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]] && { usage; exit 0; }
 
-if [[ -z "${PROJECT_OWNER:-}" ]]; then
-  if [[ -n "${GH_REPO:-}" ]]; then
-    PROJECT_OWNER="${GH_REPO%%/*}"
-  else
-    echo "ERROR: Set PROJECT_OWNER or GH_REPO" >&2
-    exit 1
-  fi
-fi
+GH_REPO="${GH_REPO:-$(gh repo view --json nameWithOwner -q .nameWithOwner)}"
+PROJECT_OWNER="${PROJECT_OWNER:-${GH_REPO%%/*}}"
 
 # Determine project number from env or output file (idempotent default)
 if [[ -z "${PROJECT_NUMBER:-}" ]]; then
@@ -177,3 +171,4 @@ while IFS= read -r line; do
 done < <(tail -n +2 "$DATA_FILE")
 
 echo "project fields applied (source: $DATA_FILE)."
+

--- a/SCRIPTS/ba-link-subissues.sh
+++ b/SCRIPTS/ba-link-subissues.sh
@@ -41,6 +41,8 @@ LOG_LEVEL="${LOG_LEVEL:-info}"          # debug|info|warn|error
 
 # -----------------------------------------------------------------------------
 
+GH_REPO="${GH_REPO:-$(gh repo view --json nameWithOwner -q .nameWithOwner)}"
+
 usage() {
   cat <<'USAGE'
 Usage:
@@ -57,7 +59,7 @@ Options (all optional; env vars shown in [] can also be used):
   -h, --help                         Show help
 
 Environment:
-  GH_REPO (required) e.g. "OWNER/REPO"
+  GH_REPO (optional) e.g. "OWNER/REPO" (defaults to current repo)
   GH_TOKEN (normally provided to gh by Actions)
 USAGE
 }


### PR DESCRIPTION
## Summary
- Default project scripts to current repository and owner
- Link projects using minimal `gh project link` command
- Update workflow and docs for repository-based defaults

## Testing
- `shellcheck SCRIPTS/aa-labels.sh SCRIPTS/ab-issues.sh SCRIPTS/ac-subissues.sh SCRIPTS/ad-project.sh SCRIPTS/ae-fields.sh SCRIPTS/ba-link-subissues.sh`
- `bash -n SCRIPTS/aa-labels.sh SCRIPTS/ab-issues.sh SCRIPTS/ac-subissues.sh SCRIPTS/ad-project.sh SCRIPTS/ae-fields.sh SCRIPTS/ba-link-subissues.sh`


------
https://chatgpt.com/codex/tasks/task_b_689fd22e310483239bd7c9bad4f0f8b8