### PR TITLE
Ensure error traps propagate failure

### DIFF
--- a/SCRIPTS/logging.sh
+++ b/SCRIPTS/logging.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -E
+set -Eeuo pipefail
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ERROR_LOG_FILE="$script_dir/../OUTPUTS/errors.md"
@@ -36,7 +36,7 @@ log_error() {
     [[ -n "$err" ]] && printf '%s\n' "$err"
     printf '\n'
   } >> "$ERROR_LOG_FILE"
-  return 0
+  return "$exit_code"
 }
 
 trap 'log_error $? $LINENO "$BASH_COMMAND"' ERR


### PR DESCRIPTION
## Summary
- enable strict bash error handling in `SCRIPTS/logging.sh`
- return the trapped exit status so failures propagate

## Testing
- `shellcheck SCRIPTS/logging.sh`
- `bash -c '. SCRIPTS/logging.sh; false'; echo $?`
- `tail -n 20 OUTPUTS/errors.md`


------
https://chatgpt.com/codex/tasks/task_b_68a049bdc9588323bf8af7f81d7b8661