### PR TITLE
docs: remove template workflow references

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Automates label, issue, sub-issue and project creation from a TSV/CSV.
  
 | Workflows | Scripts | Outputs | Paths |
 | --- | --- | --- | --- |
-| [`manual-import-v3.yml`](.github/workflows/manual-import-v3.yml)<br>[`link-subissues.yml`](.github/workflows/link-subissues.yml)<br>[`template.yml`](.github/workflows/template.yml) | [`aa-labels.sh`](SCRIPTS/aa-labels.sh)<br>[`ab-issues.sh`](SCRIPTS/ab-issues.sh)<br>[`ac-subissues.sh`](SCRIPTS/ac-subissues.sh)<br>[`ad-project.sh`](SCRIPTS/ad-project.sh)<br>[`ae-fields.sh`](SCRIPTS/ae-fields.sh)<br>[`ba-link-subissues.sh`](SCRIPTS/ba-link-subissues.sh)<br>[`logging.sh`](SCRIPTS/logging.sh)<br>[`purge_ALL-localrun.sh`](SCRIPTS/purge_ALL-localrun.sh) | [`issue_map.tsv`](OUTPUTS/issue_map.tsv)<br>[`subissue_map.tsv`](OUTPUTS/subissue_map.tsv)<br>[`project_number.txt`](OUTPUTS/project_number.txt)<br>[`errors.md`](OUTPUTS/errors.md)<br>[`info.md`](OUTPUTS/info.md) | [`TSV_HERE/`](TSV_HERE/)<br>[`OUTPUTS/`](OUTPUTS/)<br>[`SCRIPTS/`](SCRIPTS/)<br>[`.github/workflows/`](.github/workflows/) |
+| [`manual-import-v3.yml`](.github/workflows/manual-import-v3.yml)<br>[`link-subissues.yml`](.github/workflows/link-subissues.yml) | [`aa-labels.sh`](SCRIPTS/aa-labels.sh)<br>[`ab-issues.sh`](SCRIPTS/ab-issues.sh)<br>[`ac-subissues.sh`](SCRIPTS/ac-subissues.sh)<br>[`ad-project.sh`](SCRIPTS/ad-project.sh)<br>[`ae-fields.sh`](SCRIPTS/ae-fields.sh)<br>[`ba-link-subissues.sh`](SCRIPTS/ba-link-subissues.sh)<br>[`logging.sh`](SCRIPTS/logging.sh)<br>[`purge_ALL-localrun.sh`](SCRIPTS/purge_ALL-localrun.sh) | [`issue_map.tsv`](OUTPUTS/issue_map.tsv)<br>[`subissue_map.tsv`](OUTPUTS/subissue_map.tsv)<br>[`project_number.txt`](OUTPUTS/project_number.txt)<br>[`errors.md`](OUTPUTS/errors.md)<br>[`info.md`](OUTPUTS/info.md) | [`TSV_HERE/`](TSV_HERE/)<br>[`OUTPUTS/`](OUTPUTS/)<br>[`SCRIPTS/`](SCRIPTS/)<br>[`.github/workflows/`](.github/workflows/) |
 
 ## Script Catalog
 | Script | Role | Inputs | Outputs |
@@ -25,7 +25,6 @@ Automates label, issue, sub-issue and project creation from a TSV/CSV.
 |---|---|
 | [`manual-import-v3.yml`](.github/workflows/manual-import-v3.yml) | run selected scripts from the web UI (`run_all` or toggles) |
 | [`link-subissues.yml`](.github/workflows/link-subissues.yml) | scan issues and link task-list references |
-| [`template.yml`](.github/workflows/template.yml) | example workflow (unused) |
 
 ## Data Flow
 ```


### PR DESCRIPTION
## Summary
- drop leftover template workflow from Quick Links and Workflows tables
- note actual workflow files: manual-import-v3.yml and link-subissues.yml

## Testing
- `npx --yes markdownlint-cli README.md` *(fails: multiple lint warnings remain)*


------
https://chatgpt.com/codex/tasks/task_b_68a04a186ae88323aa8486a770fb2d13