### PR TITLE
Ensure fields JSON cleaned up on exit

### DIFF
--- a/SCRIPTS/ae-fields.sh
+++ b/SCRIPTS/ae-fields.sh
@@ -101,7 +101,7 @@ done
 (( TITLE_IDX >= 0 )) || { echo "ERROR: no *title* column in $DATA_FILE"; exit 1; }
 
 # ---- Cache fields json for idempotent checks ----
-FIELDS_JSON="$(mktemp)"; trap 'rm -f "$FIELDS_JSON"' RETURN
+FIELDS_JSON="$(mktemp)"; trap 'rm -f "$FIELDS_JSON"' EXIT
 gh project field-list "$PROJECT_NUMBER" --owner "$PROJECT_OWNER" --format json > "$FIELDS_JSON"
 
 ensure_field(){


### PR DESCRIPTION
## Summary
- Ensure `FIELDS_JSON` temp file is removed on all exit paths using an `EXIT` trap

## Testing
- `shellcheck -x SCRIPTS/ae-fields.sh`


------
https://chatgpt.com/codex/tasks/task_b_68a051ed1b208323adbff3f9642bfb4c