### PR TITLE
Handle final line in subissue import

### DIFF
--- a/SCRIPTS/ac-subissues.sh
+++ b/SCRIPTS/ac-subissues.sh
@@ -69,7 +69,9 @@ done
 TMPDIR="$(mktemp -d)"; trap 'rm -rf "$TMPDIR"' EXIT
 
 # Process rows
-while IFS= read -r line; do
+# Handle files missing a trailing newline by processing the final line even if
+# `read` returns a non-zero status.
+while IFS= read -r line || [[ -n "$line" ]]; do
   mapfile -t vals < <(
     printf '%s' "$line" | tr -d '\r' |
     awk -v FS="$DELIM" '{for(i=1;i<=NF;i++) print $i}'
@@ -119,3 +121,4 @@ done < <(tail -n +2 "$DATA_FILE")
 
 echo "sub-issues done (source: $DATA_FILE). map: $SUBMAP_OUT"
 
+exit 0


### PR DESCRIPTION
## Summary
- ensure `ac-subissues.sh` processes the final line even when the TSV lacks a trailing newline
- explicitly exit after sub-issue import to avoid lingering process

## Testing
- `shellcheck SCRIPTS/ac-subissues.sh`
- `bash -n SCRIPTS/ac-subissues.sh`


------
https://chatgpt.com/codex/tasks/task_b_68a0952bb0f0832381dc04702405a12d